### PR TITLE
Remove "docs" from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(name='Galaxy-ML',
       long_description=long_description,
       long_description_content_type="text/markdown",
       url='https://github.com/goeckslab/Galaxy-ML/',
-      packages=find_packages(exclude=['tests*', 'test-data*', 'tools*']),
+      packages=find_packages(exclude=['docs', 'tests*', 'test-data*', 'tools*']),
       package_data={
           '': ['README.md',
                'requirements.txt']},


### PR DESCRIPTION
The `docs` directory has a `__init__.py` and is as such recognized by `setuptools.find_packages` as a package.
Thus, a separate `docs` package is included in the distributed packages.
```
$ curl -sLO https://pypi.io/packages/cp36/G/Galaxy_ML/Galaxy_ML-0.8.2-cp36-cp36m-macosx_10_7_x86_64.whl
$ bsdtar -tvf Galaxy_ML-0.8.2-cp36-cp36m-macosx_10_7_x86_64.whl docs
-rw-r--r--  0 0      0           0 Jan  7  2020 docs/__init__.py
-rw-r--r--  0 0      0       16671 Jan  7  2020 docs/autogen.py
-rw-r--r--  0 0      0        2702 Jan  7  2020 docs/structure.py
```

I added `docs` to the `exclude` list to avoid that.
Since it's only a small packaging-related change, I did nothing from the checklist below, forgive me :).
### Pull Request Checklist

- [ ] Check python style, using `flake8 ./galaxy_ml`.
- [ ] Run API tests, using `cd galaxy_ml; nosetests ./tests -sv`.
- [ ] Check tool lint, using `cd galaxy_ml/tools; planemo lint`.
- [ ] Run tool tests, using `cd galaxy_ml/tools; planemo test`.
- [ ] Update `docs/CHANGELOG`, if applicable.
- [ ] Update `README.md`, if applicable.
